### PR TITLE
deactivate text-scale-mode to reset all text scaling

### DIFF
--- a/darkroom.el
+++ b/darkroom.el
@@ -304,7 +304,7 @@ With optional JUST-MARGINS, just set the margins."
             (set (make-local-variable (car pair)) (cdr pair)))
         darkroom--saved-state)
   (setq darkroom--saved-state nil)
-  (text-scale-decrease darkroom-text-scale-increase)
+  (text-scale-mode -1)
   (mapc #'(lambda (w)
             (with-selected-window w
               (darkroom--reset-margins)))


### PR DESCRIPTION
Fixes #10 

From the documentation of `increase-text-scale`

> Increase the height of the default face in the current buffer by INC steps.
> If the new height is other than the default, ‘text-scale-mode’ is enabled.

Contrary to what it sounds like, disabling `text-scale-mode` does not prevent further scaling.