### PR TITLE
wrong BOUND parameter in darkroom-guess-margins

### DIFF
--- a/darkroom.el
+++ b/darkroom.el
@@ -171,7 +171,7 @@ window's geometry."
                            (goto-char (point-min))
                            (cl-loop for start = (point)
                                     while (search-forward "\n"
-                                                          20000
+                                                          (+ 20000 (point-min))
                                                           'no-error)
                                     for width = (truncate
                                                  (car


### PR DESCRIPTION
Hey,

darkroom-mode failed to calculate margins for me in `Info-mode` with an error message
`Invalid search bound (wrong side of point)` on this exact `search-forward` function call.

I am not sure what would be the reason for this behavior, but `search-forward` allows specifying nil for the BOUND parameter, which causes `search-forward` to search until the end of the accessible portion of the buffer and as a side effect immediately corrected the error for me.

I don't really see why 20000 is used as a "magic constant" here, and if there is a reason, I will be happy to stand corrected and research other possible solutions.

Cheers.